### PR TITLE
BAM-1014 rule venues in paris report an error because the floor price is too high

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# Singtime - Default EditorConfig
+#
+# References:
+#   https://EditorConfig.org
+#   https://editorconfig-specification.readthedocs.io/
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,7 +9,7 @@ import { devices } from '@playwright/test';
 const config: PlaywrightTestConfig = {
   testDir: './tests',
   /* Maximum time one test can run for. */
-  timeout: 30 * 1000,
+  timeout: 210000,
   expect: {
     /**
      * Maximum time expect() should wait for the condition to be met.

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -27,7 +27,7 @@ const config: PlaywrightTestConfig = {
   /* Shared settings for all the projects below. */
   use: {
     /* Maximum time each action such as `click()` can take. */
-    actionTimeout: 6000,
+    actionTimeout: 7000,
 
     /* Collect trace when a test fail. Check at the end of the report */
     trace: 'retain-on-failure',

--- a/tests/testPrice.spec.ts
+++ b/tests/testPrice.spec.ts
@@ -8,15 +8,15 @@ const BASE_URL = 'https://backend.bam-karaokebox.com/index.php/login_backend?utm
 const VENUES = [{
   name: 'Richer',
   id: 2,
-  floorPrice: 5,
+  floorPrice: 4.5,
 }, {
   name: 'Sentier',
   id: 3,
-  floorPrice: 5,
+  floorPrice: 4.5,
 }, {
   name: 'Parmentier',
   id: 4,
-  floorPrice: 5,
+  floorPrice: 4.5,
 }, {
   name: 'Chartrons',
   id: 5,
@@ -28,12 +28,11 @@ const VENUES = [{
 }, {
   name: 'Madeleine',
   id: 7,
-  floorPrice: 5,
-},
-{
+  floorPrice: 4.5,
+}, {
   name: 'Etoile',
   id: 8,
-  floorPrice: 5,
+  floorPrice: 4.5,
 }];
 
 let listdata: any = [];

--- a/tests/testPrice.spec.ts
+++ b/tests/testPrice.spec.ts
@@ -110,8 +110,6 @@ const checkPrice = async (page: any, venuePath: any) => {
 };
 
 const checkPriceforeachVenues = async (page: any, venuePath: any) => {
-    { test.setTimeout(210000); }
-
     await page.locator('select[name="calendar_place"]').selectOption(JSON.stringify(venuePath.id));
     await page.waitForSelector('.booking .calendar .screen');
 

--- a/tests/testPrice.spec.ts
+++ b/tests/testPrice.spec.ts
@@ -35,85 +35,76 @@ const VENUES = [{
   floorPrice: 4.5,
 }];
 
-let listdata: any = [];
-const Erreur: any = [];
-let Creneau: string[];
-let PrixSalle: string[];
-let PrixPerson: string[];
+const Errors: any = [];
 
 const getdata = async (page: any, value: number) => {
-  const getCreneau = await page.evaluate((data: number = value) => {
-    const ListeSeance = [];
-    const NumberSlot = document.querySelectorAll('div.slot.available').length;
-    for (let i = 0; i < NumberSlot; i++) {
-      ListeSeance.push(document.querySelectorAll('div.slot.available')[i].childNodes[data].nodeValue);
-    }
-    return (ListeSeance);
-    }, value);
-  return (listdata = getCreneau);
+  return await page.evaluate((data: number = value) => {
+    return Array
+      .from(document.querySelectorAll('div.slot.available'))
+      .map(slot => (slot.childNodes[data].nodeValue || '').trim());
+  }, value);
 };
 
 const checkPrice = async (page: any, venuePath: any) => {
-
   await page.waitForSelector('.booking .calendar .screen');
 
   // Create a list compose of the "name" of room and date of each available slot
-  const RoomSlot = await page.evaluate(() => {
-    const ListeSalle = [];
-    const NumberRoom = document.querySelectorAll('.screen').length;
+  const roomSlots = await page.evaluate(() => {
+    const rooms = [];
+    const roomNumber = document.querySelectorAll('.screen').length;
     let date;
     date = document.querySelectorAll('div.slot input')[0].dataset.bookingDate;
     date = date.substring(6, 10) + '/' + date.substring(0, 2) + '/' + date.substring(3, 5);
-    for (let j = 0; j < NumberRoom; j++) {
-      const RoomName = document.querySelectorAll('div.capacity')[j].childNodes[0].nodeValue;
-      const NumberSlot = document.querySelectorAll('div.places')[j].querySelectorAll('div.available').length;
-      if (NumberSlot !== 0) {
-        for (let i = 0; i < NumberSlot; i++) {
-          ListeSalle.push(RoomName + date);
+    const capacities = document.querySelectorAll('div.capacity');
+    const places = document.querySelectorAll('div.places');
+    for (let j = 0; j < roomNumber; j++) {
+      const roomName = (capacities[j].childNodes[0].nodeValue || '').replace('Salle', '').trim();
+      const numberSlot = places[j].querySelectorAll('div.available').length;
+      if (numberSlot !== 0) {
+        for (let i = 0; i < numberSlot; i++) {
+          rooms.push(`${roomName} (${date})`);
         }
       }
     }
-    return ListeSalle;
+    return rooms;
   });
 
   // Create a list compose of slot duration
-  const HourSlot = await page.evaluate(() => {
-    const ListeTime = [];
-    const NumberSlot = document.querySelectorAll('div.slot.available').length;
-    for (let i = 0; i < NumberSlot; i++) {
-      let StartHours = document.querySelectorAll('div.available input')[i].dataset.bookingFrom;
-      let EndHours = document.querySelectorAll('div.available input')[i].dataset.bookingTo;
-      StartHours = parseInt(StartHours[0] + StartHours[1] + StartHours[3] + StartHours[4] , 10);
-      EndHours = parseInt(EndHours[0] + EndHours[1] + EndHours[3] + EndHours[4] , 10);
-      if (EndHours < 1000 && parseInt(StartHours, 10) > 1400) {
-        EndHours = EndHours + 2400;
+  const sessions = await page.evaluate(() => {
+    const sessionsList = [];
+    const slotCounts = document.querySelectorAll('div.slot.available').length;
+    const available = document.querySelectorAll('div.available input');
+    for (let i = 0; i < slotCounts; i++) {
+      const startTime = available[i].dataset.bookingFrom;
+      const endTime = available[i].dataset.bookingTo;
+      const startTimeInt = parseInt(startTime[0] + startTime[1] + startTime[3] + startTime[4] , 10);
+      let endTimeInt = parseInt(endTime[0] + endTime[1] + endTime[3] + endTime[4] , 10);
+
+      if (endTimeInt < 1000 && parseInt(startTime, 10) > 1400) {
+        endTimeInt = endTimeInt + 2400;
       }
-      ListeTime.push(JSON.stringify((EndHours - StartHours) / 100));
+      sessionsList.push(JSON.stringify((endTimeInt - startTimeInt) / 100.00));
     }
-    return (ListeTime);
-    });
+    return (sessionsList);
+  });
 
   // Create a list compose of hours of each available slot
-  await getdata(page, 0);
-  Creneau = listdata;
+  const timeSlots = await getdata(page, 0);
 
   // Create a list compose of price of each available slot
-  await getdata(page, 2);
-  PrixSalle = listdata;
+  const roomPrices = await getdata(page, 2);
 
   // Create a list compose of price per person of each available slot
-  await getdata(page, 4);
-  PrixPerson = listdata;
+  const roomPricesPerPerson = await getdata(page, 4);
 
-  // Verify the price by person between 14 hours and 3 hours then it create the list Erreur
-  for (let i = 0; i < PrixPerson.length; i++) {
-    const Result = [RoomSlot, Creneau, PrixSalle, PrixPerson];
-    const pricePerPerson = parseInt(PrixPerson[i], 10);
-    const venueFloorPrice = parseInt(venuePath.floorPrice, 10);
-    const sessionTime = HourSlot[i][0];
-    if (pricePerPerson < venueFloorPrice * sessionTime) {
-      Erreur.push(`\n Error detected at ${venuePath.name} : ${Result[0][i]} ${Result[1][i]} for ${Result[2][i]} and ${Result[3][i]}
-       we expect to have a price superior at ${venueFloorPrice * sessionTime}€ per person \n`);
+  // Verify the price by person between 14 hours and 3 hours then it create the list Errors
+  for (let i = 0; i < roomPricesPerPerson.length; i++) {
+    const pricePerPerson = parseInt(roomPricesPerPerson[i], 10);
+    const sessionTime = sessions[i][0];
+    const expectedPricePerPerson = venuePath.floorPrice * sessionTime;
+
+    if (pricePerPerson < expectedPricePerPerson) {
+      Errors.push(`${venuePath.name} - ${roomSlots[i]} [${timeSlots[i]}] => got: ${pricePerPerson}€ per person / expected: > ${expectedPricePerPerson} per person (total: ${roomPrices[i]})`);
     }
   }
 };
@@ -160,10 +151,8 @@ const checkPriceforeachVenues = async (page: any, venuePath: any) => {
         }
       }
     }
-    if (Erreur.length !== 0) {
-      throw new Error(
-        Erreur,
-      );
+    if (Errors.length !== 0) {
+      throw new Error('\n' + Errors.join('\n'));
     }
 };
 


### PR DESCRIPTION
# Fix for Test Failure

Since we deployed the automated tests, they've been mostly marked as FAILED because we have some edge-cases where prices were (rightfully) under the configured threshold. This was for instance the case for large rooms (30 people) where the price could be less than 5 EUR / person / hour.

To avoid this, and until we identify a better rule, we lower the threshold to 4.5 EUR / person / hour for Paris.
This should still allow the test to act as a decent safeguard.

# Report Format Changes

I changed the output format of the report so that it's:

 - more correct,
 - easier to parse with a regex (if I need to transform it to a csv, for instance),
 - more compact (previously the error was thrown with an array of values, now I join the array to a single string so that it doesn't skip all lines, and each error detection report is on a single line instead of 2).

e.g. this now outputs something like this:

```
Richer - Ray Charles (2022/05/02) [18:40 - 20:40] => got: 9€ per person / expected: > 10 per person (total: 72€)
Richer - BAM (2022/05/02) [18:50 - 20:50] => got: 9€ per person / expected: > 10 per person (total: 90€)
Richer - Folies (2022/05/02) [19:00 - 21:00] => got: 9€ per person / expected: > 10 per person (total: 108€)
```

(except now the actual value is 9 and not 10 ;) that's just for the test)

instead of this:

```
Error detected at Richer : Salle Ray Charles 2022/05/02 18:40 - 20:40 for 72€  and 9.00€ par personne
       we expect to have a price superior at 10€ per person 
,
 Error detected at Richer : Salle BAM 2022/05/02 18:50 - 20:50 for 90€  and 9.00€ par personne
       we expect to have a price superior at 10€ per person 
,
 Error detected at Richer : Salle Folies 2022/05/02 19:00 - 21:00 for 108€  and 9.00€ par personne
       we expect to have a price superior at 10€ per person 
,
```

# Other Changes

I made a lot of changes but overall they're all minor things:

 * reusing selectors were possible,
 * reducing the scope of some variables,
 * reducing the use of unnecessary variables,
 * moved the variables to a different scope

I also added the .editorconfig I had forgotten to add when I created the repo.

# Future Improvements?

We could:

 * parameterize tests to have a single test per venue AND date combination, for an easier report,
 * or modify the "reporter" config to create a more readable report.
